### PR TITLE
change android installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dependencies {
 }
 ```
 
-* In MainActivity.java
+* In `MainApplication.java`
 
 ```
 ...


### PR DESCRIPTION
in react-native-0.40+
I guess `getPackages` method should put on `MainApplication.java`

因为需要在android上实现弹性边界，所以按照文档修改一些`android`项目下的一些文件。
但是发现如果`getPackages`方法写在`MainActivity.java`文件后，会得到一个
`method does not override method from its superclass`
这样的Error

同时发现在`MainApplication.java`文件中存在了`getPackages`方法。
重写了该方法后就得到了想要的结果。
不知道是不是因为react-native版本的迭代导致java文件结构的变化。。