### PR TITLE
fix: onResponderRelease not work when scrolling

### DIFF
--- a/PullToRefreshListView-ios.js
+++ b/PullToRefreshListView-ios.js
@@ -160,7 +160,7 @@ class PullToRefreshListView extends Component {
                     onContentSizeChange={this._onContentSizeChange}
                     onResponderGrant={this._onResponderGrant}
                     onScroll={this._onScroll}
-                    onResponderRelease={this._onResponderRelease}>
+                    onMomentumScrollBegin={this._onResponderRelease}>
                     {this._renderHeader()}
                     {this.props.children}
                     {this._renderFooter()}
@@ -175,7 +175,7 @@ class PullToRefreshListView extends Component {
                     onContentSizeChange={this._onContentSizeChange}
                     onResponderGrant={this._onResponderGrant}
                     onScroll={this._onScroll}
-                    onResponderRelease={this._onResponderRelease}
+                    onMomentumScrollBegin={this._onResponderRelease}
                     onChangeVisibleRows={this._onChangeVisibleRows}
                     listItemProps={this.props.listItemProps}
                     renderRow={this._renderRow}


### PR DESCRIPTION
当`View`正在滑动时，我们触摸`View`并释放，并不会触发`onResponderRelease`事件，所以我将事件改为`onMomentumScrollBegin`
该事件会在开始惯性滚动时执行，惯性滚动的开始就意味着手动滚动的结束，所以理论上它可以替代`onResponderRelease`事件(^_^)v